### PR TITLE
Multi attr values

### DIFF
--- a/authnrequest.go
+++ b/authnrequest.go
@@ -21,7 +21,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/parsable/go-saml/util"
+	"github.com/99designs/go-saml/util"
 )
 
 func ParseCompressedEncodedRequest(b64RequestXML string) (*AuthnRequest, error) {

--- a/authnresponse.go
+++ b/authnresponse.go
@@ -307,12 +307,14 @@ func (r *Response) AddAttribute(name, value string) {
 		},
 		Name:       name,
 		NameFormat: "urn:oasis:names:tc:SAML:2.0:attrname-format:basic",
-		AttributeValue: AttributeValue{
-			XMLName: xml.Name{
-				Local: "saml:AttributeValue",
+		AttributeValue: []AttributeValue{
+			{
+				XMLName: xml.Name{
+					Local: "saml:AttributeValue",
+				},
+				Type:  "xs:string",
+				Value: value,
 			},
-			Type:  "xs:string",
-			Value: value,
 		},
 	})
 }
@@ -357,9 +359,21 @@ func (r *Response) CompressedEncodedSignedString(privateKeyPath string) (string,
 // GetAttribute by Name or by FriendlyName. Return blank string if not found
 func (r *Response) GetAttribute(name string) string {
 	for _, attr := range r.Assertion.AttributeStatement.Attributes {
-		if attr.Name == name || attr.FriendlyName == name {
-			return attr.AttributeValue.Value
+		if (attr.Name == name || attr.FriendlyName == name) && len(attr.AttributeValue) > 0 {
+			return attr.AttributeValue[0].Value
 		}
 	}
 	return ""
+}
+
+func (r *Response) GetAttributeValues(name string) []string {
+	v := []string{}
+	for _, attr := range r.Assertion.AttributeStatement.Attributes {
+		if (attr.Name == name || attr.FriendlyName == name) && len(attr.AttributeValue) > 0 {
+			for _, value := range attr.AttributeValue {
+				v = append(v, value.Value)
+			}
+		}
+	}
+	return v
 }

--- a/authnresponse.go
+++ b/authnresponse.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/parsable/go-saml/util"
+	"github.com/99designs/go-saml/util"
 )
 
 func ParseCompressedEncodedResponse(b64ResponseXML string) (*Response, error) {
@@ -60,7 +60,7 @@ func (r *Response) Validate(s *ServiceProviderSettings) error {
 		return errors.New("no Assertions")
 	}
 
-	if len(r.Signature.SignatureValue.Value) == 0 {
+	if len(r.Signature.SignatureValue.Value) == 0 && len(r.Assertion.Signature.SignatureValue.Value) == 0 {
 		return errors.New("no signature")
 	}
 

--- a/logoutrequest.go
+++ b/logoutrequest.go
@@ -20,7 +20,7 @@ import (
 	"encoding/xml"
 	"time"
 
-	"github.com/parsable/go-saml/util"
+	"github.com/99designs/go-saml/util"
 )
 
 // GetSignedAuthnRequest returns a singed XML document that represents a AuthnRequest SAML document

--- a/saml.go
+++ b/saml.go
@@ -1,6 +1,6 @@
 package saml
 
-import "github.com/parsable/go-saml/util"
+import "github.com/99designs/go-saml/util"
 
 // ServiceProviderSettings provides settings to configure server acting as a SAML Service Provider.
 // Expect only one IDP per SP in this configuration. If you need to configure multipe IDPs for an SP

--- a/types.go
+++ b/types.go
@@ -299,7 +299,7 @@ type Attribute struct {
 	Name           string `xml:",attr"`
 	FriendlyName   string `xml:",attr"`
 	NameFormat     string `xml:",attr"`
-	AttributeValue AttributeValue
+	AttributeValue []AttributeValue
 }
 
 type AttributeStatement struct {

--- a/xmlsec_test.go
+++ b/xmlsec_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/xml"
 	"testing"
 
-	"github.com/parsable/go-saml/util"
+	"github.com/99designs/go-saml/util"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
This library could not correctly represent the way Bitium returns group information in the SAML auth response.

Before:
```
 saml.Attribute{XMLName:xml.Name{Space:"urn:oasis:names:tc:SAML:2.0:assertion", Local:"Attribute"}, Name:"Groups", FriendlyName:"Groups", NameFormat:"urn:oasis:names:tc:SAML:2.0:attrname-format:uri", AttributeValue:saml.AttributeValue{XMLName:xml.Name{Space:"urn:oasis:names:tc:SAML:2.0:assertion", Local:"AttributeValue"}, Type:"", Value:"Phones"}}
```

After:
```
saml.Attribute{XMLName:xml.Name{Space:"urn:oasis:names:tc:SAML:2.0:assertion", Local:"Attribute"}, Name:"Groups", FriendlyName:"Groups", NameFormat:"urn:oasis:names:tc:SAML:2.0:attrname-format:uri", AttributeValue:[]saml.AttributeValue{saml.AttributeValue{XMLName:xml.Name{Space:"urn:oasis:names:tc:SAML:2.0:assertion", Local:"AttributeValue"}, Type:"", Value:"Developers"}, saml.AttributeValue{XMLName:xml.Name{Space:"urn:oasis:names:tc:SAML:2.0:assertion", Local:"AttributeValue"}, Type:"", Value:"Tech Leads"}, saml.AttributeValue{XMLName:xml.Name{Space:"urn:oasis:names:tc:SAML:2.0:assertion", Local:"AttributeValue"}, Type:"", Value:"Melbourne"}, saml.AttributeValue{XMLName:xml.Name{Space:"urn:oasis:names:tc:SAML:2.0:assertion", Local:"AttributeValue"}, Type:"", Value:"Team Leaders"}, saml.AttributeValue{XMLName:xml.Name{Space:"urn:oasis:names:tc:SAML:2.0:assertion", Local:"AttributeValue"}, Type:"", Value:"Senior Tech Leads"}, saml.AttributeValue{XMLName:xml.Name{Space:"urn:oasis:names:tc:SAML:2.0:assertion", Local:"AttributeValue"}, Type:"", Value:"Employees"}, saml.AttributeValue{XMLName:xml.Name{Space:"urn:oasis:names:tc:SAML:2.0:assertion", Local:"AttributeValue"}, Type:"", Value:"Phones"}}}
```
